### PR TITLE
Automatisches erstellen der index.html aus words.md

### DIFF
--- a/.github/workflows/compile-markdown.yml
+++ b/.github/workflows/compile-markdown.yml
@@ -1,0 +1,30 @@
+# This workflow will use words/words.md to generate a new index.html
+
+name: "Compile index.html from words.md"
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  convert_via_pandoc:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Get the current source from master
+        uses: actions/checkout@master
+      - name: Convert markdown to html
+        uses: docker://pandoc/core:2.9 # use a docker image that has pandoc pre-installed
+        with:
+          args: "--from markdown_strict+footnotes words/words.md -o words/words.html"
+      - name: Merge html files
+        run: |
+          cat index_head.html words/words.html index_tail.html > index.html
+      - name: Commit changed files
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -m "Compile index.html from Markdown" -a
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Was tut dieser PR?
Dieser PR fügt eine GitHub Action hinzu, die nach jedem push ausgeführt wird. Sobald dieser PR gemerged wird, ist diese Action automatisch aktiv.

Diese Action baut aus der aktuellen `words/words.md` zunächst die `words/words.html` und erstellt dann aus `index_head.html` und `index_tail.html` die neue `index.html`. Anschließend erzeugt die Action eigenständig einen neuen commit und pusht diesen. Damit ist `index.html` immer auf dem neusten Stand und wird immer auf die selbe weise konvertiert, egal wer die Änderung angestoßen hat.

# Wie hängt dieser PR mit PR #42 zusammen?
In #42 habe ich ein Shell-Skript hinzugefügt, das es ermöglicht, lokal (also auf dem Rechner, auf dem man dieses Repo geklont hat) die Konvertierung von Markdown zu html auszuführen. Dazu muss auf dem eigenen Rechner `pandoc` installier sein.

Dieser neue PR führt im Wesentlichen das gleiche auf der Infrastruktur von GitHub aus, und zwar automatisch nach jedem push. Das ist unabhängig von der eigenen Rechner-Konfiguration, insbesondere auch davon, ob man `pandoc` installiert hat.

**Beide PRs setzen voraus, dass die Dateien `index_head.html` und `index_tail.html` bestehen, um daraus die neue `index.hmtl` zusammen zu setzen. Während #42 die Aufteilung in beide Teile enthält, habe ich das hier _nicht_ nochmal explizit gemacht.**

Falls beide PRs gemerged werden, hätte das den Vorteil, dass man die Konvertierung lokal per Skript testen _kann_, das aber nicht _muss_, da es ja sowieso auf dem GitHub-Server (nochmal) gemacht wird.

# Wird die Action sich durch ihren Push nicht in einer Endlosschleife selbst aufrufen?
Nein. Ich weiß ehrlich gesagt nicht, warum das nicht passiert, aber beim testen [in meinem Fork](https://github.com/lenaschimmel/covid-19) ist keine Endlosschleife ausgelöst worden.