### PR TITLE
Verweise auf Quelltext reparieren, vereinheitlichen und etwas aufhübschen

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
 <!-- - - - - - - - - - - - - - - - - - - - - - - -->
 
 <div id="translations">
+	<b>Übersetzungen</b>
 	<ul>
 		<!-- IF YOU'RE MAKING A TRANSLATION, UN-COMMENT THE NEXT LINE -->
 		<li><a href='https://ncase.me/covid-19/'>English (original version)</a></li>
@@ -46,12 +47,9 @@
 		<li><a href='https://vrruiz.github.io/covid-19'>Español</a></li>
 		<li><a href='https://jusplathemus.github.io/covid-19/'>Magyar</a></li>
 	</ul>
-	<a href='https://github.com/ncase/covid-19#how-to-translate'>
-		Willst du helfen?
-		(den Quelltext <a href='https://github.com/TQueV/covid-19/'>dieser Seite</a> bzw. des<a href='https://github.com/ncase/covid-19'>englischen Originals</a>findet du auf GitHub)
 
-
-	</a>
+	<b>Willst du helfen?</b><br/>
+	Den Quelltext <a href='https://github.com/TQueV/covid-19/'>dieser Seite</a> bzw. des <a href='https://github.com/ncase/covid-19'>englischen Originals</a> findet du auf GitHub.
 </div>
 
 <div id="sharing">
@@ -518,9 +516,8 @@ die <b style='color:#888'>Graue Kurve</b> gibt die <em>gesamten</em> Fälle (akt
 		</b>
 		Das bedeutet, du hast <i>bereits</i> die Erlaubnis zur Weiterverwendung und zur Weiterbearbeitung
 		der Bilder, der Quelltexte und der Texte auf dieser Seite - in Blogs, auf Nachrichtenseiten, in der Schule, überall!
-		<a href='https://github.com/ncase/covid-19'>
-			(den Quelltext findest du auf Github)
-		</a>
+		(Den Quelltext <a href='https://github.com/TQueV/covid-19/'>dieser Seite</a> bzw. des <a href='https://github.com/ncase/covid-19'>englischen Originals</a> findet du auf GitHub.)
+
 		<br>
 		<b>
 			Bitte denke an die Quellenangaben:


### PR DESCRIPTION
Änderungen in diesem PR:

 * Überschrift "Übersetzungen" über der Liste der Übersetzungen
 * "Willst du helfen?" als Überschrift
 * Ineinander verschachtelte Links entworren. Vorher war um die links zu den beiden Repositories auch noch ein Link zu einem bestimmten Absatz in der README-Datei.
 * Leerzeichen ergänzt
 * Auch am Ende des Textes auf beides Repositories verlinkt

Vorher:
<img width="179" alt="Bildschirmfoto 2020-05-09 um 14 32 30" src="https://user-images.githubusercontent.com/1325019/81473908-3bdab400-9202-11ea-98be-c809408dc1b9.png">

Nachher:
<img width="164" alt="Bildschirmfoto 2020-05-09 um 14 32 38" src="https://user-images.githubusercontent.com/1325019/81473909-3d0be100-9202-11ea-8bf2-968b09517a33.png">
