### PR TITLE
Fix overlapping text in simulator

### DIFF
--- a/sim/css/sim.css
+++ b/sim/css/sim.css
@@ -93,13 +93,13 @@ div{
 }
 
 #sb_reset, #sb_replay{
-	position: absolute;
+    position: absolute;
     color: #999;
     font-size: 15px;
     font-weight: 100;
     cursor: pointer;
-    bottom: -22px;
-
+    bottom: -37px;
+    max-width: 120px;
     display: none;
 }
 #sb_reset:hover, #sb_replay:hover{
@@ -107,6 +107,7 @@ div{
 }
 #sb_reset{
 	right: 0px;
+	text-align: right;
 }
 
 hr{

--- a/sim/index.html
+++ b/sim/index.html
@@ -164,7 +164,7 @@
 					Alles zurücksetzen
 				</div>
 				<div id="sb_replay">
-					Erneut abspielen
+					Aufnahme erneut abspielen
 				</div>
 			</div>
 

--- a/sim/index.html
+++ b/sim/index.html
@@ -164,7 +164,7 @@
 					Alles zurücksetzen
 				</div>
 				<div id="sb_replay">
-					Aufnahme erneut abspielen
+					Erneut abspielen
 				</div>
 			</div>
 


### PR DESCRIPTION
Fixes #62.

I first tried changing the the translation. 

![image](https://user-images.githubusercontent.com/5970076/81581081-86992f00-93ae-11ea-8c6a-709e5e257eeb.png)

But that would have changed the meaning. So I changed the CSS so it would be broken in two lines.

![image](https://user-images.githubusercontent.com/5970076/81582824-c52fe900-93b0-11ea-9bca-d28dacc58852.png)

I haven't tested it in a deployment setting yet, just by viewing `sim/index.html` and unchecking `display: none;` using my browsers dev tools.
